### PR TITLE
Pin release branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@
 
 ## About
 
-The Opioid Environment Policy Scan (OEPS) is an open-source data warehouse that helps characterize helps characterize the multi-dimensional risk environment impacting opioid use and health outcomes across the United States. See the [master branch](https://github.com/GeoDaCenter/opioid-policy-scan) of this repo for more information.
+The Opioid Environment Policy Scan (OEPS) is an open-source data warehouse that helps characterize helps characterize the multi-dimensional risk environment impacting opioid use and health outcomes across the United States. See [GeoDaCenter/opioid-policy-scan](https://github.com/GeoDaCenter/opioid-policy-scan) for more info.
 
 The OEPS provides access to data at multiple spatial scales, from U.S. states down to Census tracts. It is designed to support research seeking to study environments impacting and impacted by opioid use and opioid use disorder (OUD), inform public policy, and reduce harm in communities nationwide. 
 
 This repository stores scripts used to create the OEPS Explorer dashboard. We rely on [webgeoda scaffolding](http://dhalpern.gitbook.io/webgeoda-templatesBtw) to generate this dashboard. 
 
-The OEPS Explorer lives at https://oeps.ssd.uchicago.edu/.
+The OEPS Explorer lives at https://oeps.healthyregions.org/.
 
 This project is led by the Healthy Regions & Policies Lab at the Center for Spatial Data Science, University of Chicago. 
 

--- a/components/map/VariablePanel.js
+++ b/components/map/VariablePanel.js
@@ -129,7 +129,7 @@ export default function VariablePanel(props) {
                 className={styles.readMoreButton}
                 onClick={() =>
                   setActiveDocs(
-                    `https://raw.githubusercontent.com/GeoDaCenter/opioid-policy-scan/master/data_final/metadata/${
+                    `https://raw.githubusercontent.com/GeoDaCenter/opioid-policy-scan/v1.0/data_final/metadata/${
                       variableMeta.find((f) =>
                         f.markdownPrefix.includes(
                           dataParams.numerator.split("_")[0]
@@ -151,7 +151,7 @@ export default function VariablePanel(props) {
                 className={styles.readMoreButton}
                 onClick={() =>
                   setActiveDocs(
-                    `https://raw.githubusercontent.com/GeoDaCenter/opioid-policy-scan/master/data_final/metadata/${
+                    `https://raw.githubusercontent.com/GeoDaCenter/opioid-policy-scan/v1.0/data_final/metadata/${
                       variableMeta.find((f) =>
                         f.markdownPrefix.includes(
                           dataParams.numerator.split("_")[0]

--- a/meta/variables.js
+++ b/meta/variables.js
@@ -3,7 +3,7 @@ export const variables = {
     {
       'Variable Proxy': 'State, County, Census Tract, Zip Code Tract Area (ZCTA)',
       Source: 'US Census, 2018',
-      Metadata: '<a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/master/data_final/metadata/GeographicBoundaries_2018.md">Geographic Boundaries</a>',
+      Metadata: '<a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/GeographicBoundaries_2018.md">Geographic Boundaries</a>',
       'Spatial Scale': 'State, County, Tract, Zip',
       markdownPrefix: '',
       markdownText: 'Geographic Boundaries',
@@ -13,7 +13,7 @@ export const variables = {
     {
       'Variable Proxy': 'County, Census Tract, Zip Code Tract Area (ZCTA)',
       Source: 'HUD’s Office of Policy Development and Research (PD&R)',
-      Metadata: '<a href="https://github.com/GeoDaCenter/opioid-policy-scan/master/data_final/metadata/crosswalk.md">Crosswalk Files</a>',
+      Metadata: '<a href="https://github.com/GeoDaCenter/opioid-policy-scan/v1.0/data_final/metadata/crosswalk.md">Crosswalk Files</a>',
       'Spatial Scale': 'County, Tract, Zip',
       markdownPrefix: '',
       markdownText: 'Crosswalk Files',
@@ -25,7 +25,7 @@ export const variables = {
     {
       'Variable Proxy': 'Prison population rate and prison admission rate by gender and ethnicity',
       Source: 'Vera Institute of Justice, 2016',
-      Metadata: 'PS01 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/data_final/metadata/Prison%20variables_2016.md">Prison Variables</a>',
+      Metadata: 'PS01 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/Prison%20variables_2016.md">Prison Variables</a>',
       'Spatial Scale': 'County',
       markdownPrefix: 'PS01 / ',
       markdownText: 'Prison Variables',
@@ -35,7 +35,7 @@ export const variables = {
     {
       'Variable Proxy': 'Jail population rate by gender and ethnicity',
       Source: 'Vera Institute of Justice, 2017',
-      Metadata: 'PS02 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/data_final/metadata/Jail%20variables_2017.md">Jail Variables</a>',
+      Metadata: 'PS02 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/Jail%20variables_2017.md">Jail Variables</a>',
       'Spatial Scale': 'County',
       markdownPrefix: 'PS02 / ',
       markdownText: 'Jail Variables',
@@ -45,7 +45,7 @@ export const variables = {
     {
       'Variable Proxy': 'Any PDMP; Operational PDMP; Must-access PDMP; Electronic PDMP',
       Source: 'OPTIC, 2017',
-      Metadata: 'PS03 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/data_final/metadata/PDMP_2017.md">PDMP</a>',
+      Metadata: 'PS03 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/PDMP_2017.md">PDMP</a>',
       'Spatial Scale': 'State',
       markdownPrefix: 'PS03 / ',
       markdownText: 'PDMP',
@@ -55,7 +55,7 @@ export const variables = {
     {
       'Variable Proxy': 'Any Good Samaritan Law; Good Samaritan Law protecting arrest',
       Source: 'OPTIC, 2017',
-      Metadata: 'PS04 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/data_final/metadata/GSL_2018.md">GSL</a>',
+      Metadata: 'PS04 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/GSL_2018.md">GSL</a>',
       'Spatial Scale': 'State',
       markdownPrefix: 'PS04 / ',
       markdownText: 'GSL_2018',
@@ -65,7 +65,7 @@ export const variables = {
     {
       'Variable Proxy': 'Any Naloxone law; law allowing distribution through a standing or protocal order; law allowing pharmacists prescriptive authority',
       Source: 'OPTIC, 2017',
-      Metadata: 'PS05 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/data_final/metadata/NAL_2017.md">NAL</a>',
+      Metadata: 'PS05 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/NAL_2017.md">NAL</a>',
       'Spatial Scale': 'State',
       markdownPrefix: 'PS05 / ',
       markdownText: 'NAL',
@@ -75,7 +75,7 @@ export const variables = {
     {
       'Variable Proxy': 'Total Medicaid spending',
       Source: 'KFF, 2019',
-      Metadata: 'PS06 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/data_final/metadata/MedExp_2019.md">MedExp</a>',
+      Metadata: 'PS06 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/MedExp_2019.md">MedExp</a>',
       'Spatial Scale': 'State',
       markdownPrefix: 'PS06 / ',
       markdownText: 'MedExp',
@@ -85,7 +85,7 @@ export const variables = {
     {
       'Variable Proxy': 'Spending for adults who have enrolled through Medicaid expansion',
       Source: 'KFF, 2018',
-      Metadata: 'PS07 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/data_final/metadata/MedExpan_2018.md">MedExpan</a>',
+      Metadata: 'PS07 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/MedExpan_2018.md">MedExpan</a>',
       'Spatial Scale': 'State',
       markdownPrefix: 'PS07 / ',
       markdownText: 'MedExpan',
@@ -95,7 +95,7 @@ export const variables = {
     {
       'Variable Proxy': 'Laws clarifying legal status for syringe exchange, distribution, and possession programs',
       Source: 'LawAtlas, 2019',
-      Metadata: 'PS08 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/data_final/metadata/Syringe.md">Syringe</a>',
+      Metadata: 'PS08 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/Syringe.md">Syringe</a>',
       'Spatial Scale': 'State',
       markdownPrefix: 'PS08 / ',
       markdownText: 'Syringe',
@@ -128,7 +128,7 @@ export const variables = {
     {
       'Variable Proxy': 'Death rate from drug-related causes',
       Source: 'CDC WONDER, 2009-2019',
-      Metadata: 'Health01 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/data_final/metadata/Health_DrugDeaths.md">Drug-Related Death Rate</a>',
+      Metadata: 'Health01 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/Health_DrugDeaths.md">Drug-Related Death Rate</a>',
       'Spatial Scale': 'State, County',
       markdownPrefix: 'Health01 / ',
       markdownText: 'Drug-Related Death Rate',
@@ -148,7 +148,7 @@ export const variables = {
     {
       'Variable Proxy': 'Number of Primary Care and Specialist Physicians',
       Source: 'Dartmouth Atlas, 2010',
-      Metadata: 'Health03 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/data_final/metadata/Health_PCPs.md">Physicians</a>',
+      Metadata: 'Health03 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/Health_PCPs.md">Physicians</a>',
       'Spatial Scale': 'Tract, County, State',
       markdownPrefix: 'Health03 / ',
       markdownText: 'Physicians',
@@ -158,7 +158,7 @@ export const variables = {
     {
       'Variable Proxy': 'Opioid Prescription Rates',
       Source: 'HepVu, CDC, 2018-2019',
-      Metadata: 'Health04 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/data_final/metadata/OpioidIndicators.md">Opioid Indicators</a>',
+      Metadata: 'Health04 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/OpioidIndicators.md">Opioid Indicators</a>',
       'Spatial Scale': 'County, State',
       markdownPrefix: 'Health04 / ',
       markdownText: 'Opioid Prescription Rates',
@@ -168,7 +168,7 @@ export const variables = {
     {
       'Variable Proxy': 'Opioid Mortality Rates',
       Source: 'HepVu, NVSS, 2014-2019',
-      Metadata: 'Health04 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/data_final/metadata/OpioidIndicators.md">Opioid Indicators</a>',
+      Metadata: 'Health04 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/OpioidIndicators.md">Opioid Indicators</a>',
       'Spatial Scale': 'County, State',
       markdownPrefix: 'Health04 / ',
       markdownText: 'Opioid Mortality Rates',
@@ -188,7 +188,7 @@ export const variables = {
     {
       'Variable Proxy': 'Access to FQHCs',
       Source: 'US Covid Atlas via HRSA, 2020',
-      Metadata: 'Access02 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/data_final/metadata/Access_FQHCs_MinDistance.md">Access: FQHCs</a>',
+      Metadata: 'Access02 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/Access_FQHCs_MinDistance.md">Access: FQHCs</a>',
       'Spatial Scale': 'Tract, Zip, County, State',
       markdownPrefix: 'Access02 / ',
       markdownText: 'Access: FQHCs',
@@ -198,7 +198,7 @@ export const variables = {
     {
       'Variable Proxy': 'Access to hospitals',
       Source: 'CovidCareMap, 2020',
-      Metadata: 'Access03 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/data_final/metadata/Acesss_Hospitals_MinDistance.md">Access: Hospitals</a>',
+      Metadata: 'Access03 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/Acesss_Hospitals_MinDistance.md">Access: Hospitals</a>',
       'Spatial Scale': 'Tract, Zip, County, State',
       markdownPrefix: 'Access03 / ',
       markdownText: 'Access: Hospitals',
@@ -208,7 +208,7 @@ export const variables = {
     {
       'Variable Proxy': 'Access to pharmacies',
       Source: 'InfoGroup, 2019',
-      Metadata: 'Access04 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/data_final/metadata/Access_Pharmacies_MinDistance.md">Access: Pharmacies</a>',
+      Metadata: 'Access04 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/Access_Pharmacies_MinDistance.md">Access: Pharmacies</a>',
       'Spatial Scale': 'Tract, Zip, County, State',
       markdownPrefix: 'Access04 / ',
       markdownText: 'Access: Pharmacies',
@@ -218,7 +218,7 @@ export const variables = {
     {
       'Variable Proxy': 'Access to mental health providers',
       Source: 'SAMHSA, 2020',
-      Metadata: 'Access05 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/data_final/metadata/Access_MentalHealth_MinDistance.md">Access: Mental Health Providers</a>',
+      Metadata: 'Access05 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/Access_MentalHealth_MinDistance.md">Access: Mental Health Providers</a>',
       'Spatial Scale': 'Tract, Zip, County, State',
       markdownPrefix: 'Access05 / ',
       markdownText: 'Access: Mental Health Providers',
@@ -228,7 +228,7 @@ export const variables = {
     {
       'Variable Proxy': 'Access substance use treatment (SUT) programs',
       Source: 'SAMHSA, 2020',
-      Metadata: 'Access06 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/data_final/metadata/Access_SubstanceUseTreatment.md">Access: SUT</a>',
+      Metadata: 'Access06 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/Access_SubstanceUseTreatment.md">Access: SUT</a>',
       'Spatial Scale': 'Tract, Zip, County, State',
       markdownPrefix: 'Access06 / ',
       markdownText: 'Access: Substance Use Treatment Programs',
@@ -238,7 +238,7 @@ export const variables = {
     {
       'Variable Proxy': 'Access to opioid treatment programs (OTP)',
       Source: 'SAMHSA, 2021',
-      Metadata: 'Access07 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/data_final/metadata/Access_OpioidUseTreatment.md">Access: OTP</a>',
+      Metadata: 'Access07 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/Access_OpioidUseTreatment.md">Access: OTP</a>',
       'Spatial Scale': 'Tract, Zip',
       markdownPrefix: 'Access07 / ',
       markdownText: 'Access: Opioid Treatment Programs',
@@ -251,7 +251,7 @@ export const variables = {
     {
       'Variable Proxy': 'Percentages of population defined by categories of race and ethnicity',
       Source: 'ACS, 2018 5-year',
-      Metadata: 'DS01/ <a href="https://github.com/GeoDaCenter/opioid-policy-scan/data_final/metadata/Race_Ethnicity_2018.md">Race & Ethnicity Variables</a>',
+      Metadata: 'DS01/ <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/Race_Ethnicity_2018.md">Race & Ethnicity Variables</a>',
       'Spatial Scale': 'State, County, Tract, Zip',
       markdownPrefix: '',
       markdownText: 'Race & Ethnicity Variables',
@@ -261,7 +261,7 @@ export const variables = {
     {
       'Variable Proxy': 'Age group estimates and percentages of population',
       Source: 'ACS, 2018 5-year',
-      Metadata: 'DS01 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/data_final/metadata/Age_2018.md">Age Variables</a>',
+      Metadata: 'DS01 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/Age_2018.md">Age Variables</a>',
       'Spatial Scale': 'State, County, Tract, Zip',
       markdownPrefix: 'DS01 / ',
       markdownText: 'Age Variables',
@@ -271,7 +271,7 @@ export const variables = {
     {
       'Variable Proxy': 'Percentage of population with a disability',
       Source: 'ACS, 2018 5-year',
-      Metadata: 'DS01 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/data_final/metadata/Other_Demographic_2018.md">Other Demographic Variables</a>',
+      Metadata: 'DS01 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/Other_Demographic_2018.md">Other Demographic Variables</a>',
       'Spatial Scale': 'State, County, Tract, Zip',
       markdownPrefix: 'DS01 / ',
       markdownText: 'Other Demographic Variables',
@@ -281,7 +281,7 @@ export const variables = {
     {
       'Variable Proxy': 'Population without a high school degree',
       Source: 'ACS, 2018 5-year',
-      Metadata: 'DS01 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/data_final/metadata/Other_Demographic_2018.md">Other Demographic Variables</a>',
+      Metadata: 'DS01 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/Other_Demographic_2018.md">Other Demographic Variables</a>',
       'Spatial Scale': 'State, County, Tract, Zip',
       markdownPrefix: 'DS01 / ',
       markdownText: 'Other Demographic Variables',
@@ -291,7 +291,7 @@ export const variables = {
     {
       'Variable Proxy': 'SDOH Neighborhood Typologies',
       Source: 'Kolak et al, 2020',
-      Metadata: 'DS02 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/data_final/metadata/SDOH_2014.md">SDOH Typology</a>',
+      Metadata: 'DS02 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/SDOH_2014.md">SDOH Typology</a>',
       'Spatial Scale': 'Tract',
       markdownPrefix: 'DS02 / ',
       markdownText: 'SDOH Typology',
@@ -301,7 +301,7 @@ export const variables = {
     {
       'Variable Proxy': 'SVI Rankings',
       Source: 'CDC, 2018',
-      Metadata: 'DS03 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/data_final/metadata/SVI_2018.md">SVI</a>',
+      Metadata: 'DS03 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/SVI_2018.md">SVI</a>',
       'Spatial Scale': 'County, Tract',
       markdownPrefix: 'DS03 / ',
       markdownText: 'SVI',
@@ -311,7 +311,7 @@ export const variables = {
     {
       'Variable Proxy': 'Population as defined by veteran status',
       Source: 'ACS, 2017 5-year',
-      Metadata: 'DS04 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/data_final/metadata/VetPop.md">Veteran Population Variables</a>',
+      Metadata: 'DS04 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/VetPop.md">Veteran Population Variables</a>',
       'Spatial Scale': 'State, County, Tract, Zip',
       markdownPrefix: 'DS04 / ',
       markdownText: 'Veteran Population Variables',
@@ -321,7 +321,7 @@ export const variables = {
     {
       'Variable Proxy': 'Household types and group quarter populations',
       Source: 'ACS, 2018 5-year',
-      Metadata: 'DS05 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/data_final/metadata/HouseholdType.md">Housing Type Variables</a>',
+      Metadata: 'DS05 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/HouseholdType.md">Housing Type Variables</a>',
       'Spatial Scale': 'State, County, Tract, Zip',
       markdownPrefix: 'DS05 / ',
       markdownText: 'Household Type',
@@ -331,7 +331,7 @@ export const variables = {
     {
       'Variable Proxy': 'Homelessness as defined by US Homeless Census',
       Source: 'HUD, 2018',
-      Metadata: 'DS06 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/data_final/metadata/HomelessPop.md">Homeless Population Variables</a>',
+      Metadata: 'DS06 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/HomelessPop.md">Homeless Population Variables</a>',
       'Spatial Scale': 'State, County, Tract, Zip',
       markdownPrefix: 'DS06 / ',
       markdownText: 'Homeless Population Variables',
@@ -344,7 +344,7 @@ export const variables = {
     {
       'Variable Proxy': 'Percentage of population employed in High Risk of Injury Jobs, Educational Services, Health Care, Retail industries',
       Source: 'ACS, 2018 5-year',
-      Metadata: 'EC01 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/data_final/metadata/Job_Categories_byIndustry_2018.md">Jobs by Industry</a>',
+      Metadata: 'EC01 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/Job_Categories_byIndustry_2018.md">Jobs by Industry</a>',
       'Spatial Scale': 'State, County, Tract, Zip',
       markdownPrefix: 'EC01 / ',
       markdownText: 'Jobs by Industry',
@@ -354,7 +354,7 @@ export const variables = {
     {
       'Variable Proxy': 'Percentage of population employed in Essential Jobs as defined during the COVID-19 pandemic (see COVID-19 Variables, below)',
       Source: 'ACS, 2018 5-year',
-      Metadata: 'EC02 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/data_final/metadata/Job_Categories_byIndustry_2018.md">Jobs by Industry</a>',
+      Metadata: 'EC02 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/Job_Categories_byIndustry_2018.md">Jobs by Industry</a>',
       'Spatial Scale': 'State, County, Tract, Zip',
       markdownPrefix: 'EC02 / ',
       markdownText: 'Jobs by Industry',
@@ -364,7 +364,7 @@ export const variables = {
     {
       'Variable Proxy': 'Unemployment rate',
       Source: 'ACS, 2014-2018',
-      Metadata: 'EC03 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/data_final/metadata/Economic_2018.md">Economic Variables</a>',
+      Metadata: 'EC03 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/Economic_2018.md">Economic Variables</a>',
       'Spatial Scale': 'State, County, Tract, Zip',
       markdownPrefix: 'EC03 / ',
       markdownText: 'Economic Variables',
@@ -374,7 +374,7 @@ export const variables = {
     {
       'Variable Proxy': 'Percent classified as below poverty level, based on income',
       Source: 'ACS, 2018 5-year',
-      Metadata: 'EC03 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/data_final/metadata/Economic_2018.md">Economic Variables</a>',
+      Metadata: 'EC03 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/Economic_2018.md">Economic Variables</a>',
       'Spatial Scale': 'State, County, Tract, Zip',
       markdownPrefix: 'EC03 / ',
       markdownText: 'Economic Variables',
@@ -384,7 +384,7 @@ export const variables = {
     {
       'Variable Proxy': 'Per capita income in the past 12 months',
       Source: 'ACS, 2018 5-year',
-      Metadata: 'EC03 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/data_final/metadata/Economic_2018.md">Economic Variables</a>',
+      Metadata: 'EC03 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/Economic_2018.md">Economic Variables</a>',
       'Spatial Scale': 'State, County, Tract, Zip',
       markdownPrefix: 'EC03 / ',
       markdownText: 'Economic Variables',
@@ -394,7 +394,7 @@ export const variables = {
     {
       'Variable Proxy': 'Mortgage foreclosure and severe delinquency rate',
       Source: 'HUD, 2009',
-      Metadata: 'EC04 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/data_final/metadata/ForeclosureRate.md">Foreclosure Rate</a>',
+      Metadata: 'EC04 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/ForeclosureRate.md">Foreclosure Rate</a>',
       'Spatial Scale': 'State, County, Tract',
       markdownPrefix: 'EC04 / ',
       markdownText: 'Foreclosure Rate',
@@ -404,7 +404,7 @@ export const variables = {
     {
       'Variable Proxy': 'Percent of households without internet access',
       Source: 'ACS, 2019 5-year',
-      Metadata: 'EC05 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/data_final/metadata/Internet_2019.md">Internet Access</a>',
+      Metadata: 'EC05 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/Internet_2019.md">Internet Access</a>',
       'Spatial Scale': 'State, County, Tract, Zip',
       markdownPrefix: 'EC05 / ',
       markdownText: 'Internet Access',
@@ -416,7 +416,7 @@ export const variables = {
     {
       'Variable Proxy': 'Percent occupied units',
       Source: 'ACS, 2018 5-year',
-      Metadata: 'BE01 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/data_final/metadata/Housing_2018.md">Housing</a>',
+      Metadata: 'BE01 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/Housing_2018.md">Housing</a>',
       'Spatial Scale': 'State, County, Tract, Zip',
       markdownPrefix: 'BE01 / ',
       markdownText: 'Housing',
@@ -426,7 +426,7 @@ export const variables = {
     {
       'Variable Proxy': 'Percent vacant units',
       Source: 'ACS, 2018 5-year',
-      Metadata: 'BE01 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/data_final/metadata/Housing_2018.md">Housing</a>',
+      Metadata: 'BE01 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/Housing_2018.md">Housing</a>',
       'Spatial Scale': 'State, County, Tract, Zip',
       markdownPrefix: 'BE01 / ',
       markdownText: 'Housing',
@@ -436,7 +436,7 @@ export const variables = {
     {
       'Variable Proxy': 'Percentage of population living in current housing for 20+ years',
       Source: 'ACS, 2018 5-year',
-      Metadata: 'BE01 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/data_final/metadata/Housing_2018.md">Housing</a>',
+      Metadata: 'BE01 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/Housing_2018.md">Housing</a>',
       'Spatial Scale': 'State, County, Tract, Zip',
       markdownPrefix: 'BE01 / ',
       markdownText: 'Housing',
@@ -456,7 +456,7 @@ export const variables = {
     {
       'Variable Proxy': 'Percent of housing units occupied by renters',
       Source: 'ACS, 2018 5-year',
-      Metadata: 'BE01 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/data_final/metadata/Housing_2018.md">Housing</a>',
+      Metadata: 'BE01 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/Housing_2018.md">Housing</a>',
       'Spatial Scale': 'State, County, Tract, Zip',
       markdownPrefix: 'BE01 / ',
       markdownText: 'Housing',
@@ -466,7 +466,7 @@ export const variables = {
     {
       'Variable Proxy': 'Housing units per square mile',
       Source: 'ACS, 2018 5-year',
-      Metadata: 'BE01 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/data_final/metadata/Housing_2018.md">Housing</a>',
+      Metadata: 'BE01 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/Housing_2018.md">Housing</a>',
       'Spatial Scale': 'State, County, Tract, Zip',
       markdownPrefix: 'BE01 / ',
       markdownText: 'Housing',
@@ -476,7 +476,7 @@ export const variables = {
     {
       'Variable Proxy': 'Classification of areas as rural, urban or suburban using percent rurality (County)',
       Source: 'USDA-ERS, 2010 & ACS, 2018 5-year',
-      Metadata: 'BE02 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/data_final/metadata/Rural_Urban_Classification_County.md">Rural-Urban Classifications (County)</a>',
+      Metadata: 'BE02 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/Rural_Urban_Classification_County.md">Rural-Urban Classifications (County)</a>',
       'Spatial Scale': 'County',
       markdownPrefix: 'BE02 / ',
       markdownText: 'Rural-Urban Classifications',
@@ -486,7 +486,7 @@ export const variables = {
     {
       'Variable Proxy': 'Classification of areas as rural, urban or suburban using RUCA Codes (Tract, Zip)',
       Source: 'USDA-ERS, 2010',
-      Metadata: 'BE02 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/data_final/metadata/Rural_Urban_Classification_T_Z.md">Rural-Urban Classifications (Tract, Zip)</a>',
+      Metadata: 'BE02 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/Rural_Urban_Classification_T_Z.md">Rural-Urban Classifications (Tract, Zip)</a>',
       'Spatial Scale': 'Tract, Zip',
       markdownPrefix: 'BE02 / ',
       markdownText: 'Rural-Urban Classifications',
@@ -496,7 +496,7 @@ export const variables = {
     {
       'Variable Proxy': 'Alcohol outlets per square mile, alcohol outlets per capita',
       Source: 'InfoGroup, 2018',
-      Metadata: 'BE03 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/data_final/metadata/AlcoholOutlets_2018.md">Alcohol Outlets</a>',
+      Metadata: 'BE03 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/AlcoholOutlets_2018.md">Alcohol Outlets</a>',
       'Spatial Scale': 'State, County, Tract, Zip',
       markdownPrefix: 'BE03 / ',
       markdownText: 'Alcohol Outlets',
@@ -506,7 +506,7 @@ export const variables = {
     {
       'Variable Proxy': 'US metropolitan areas where black residents experience hypersegregation',
       Source: 'Massey et al, 2015',
-      Metadata: 'BE04 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/data_final/metadata/Overlay.md">Community Overlays</a>',
+      Metadata: 'BE04 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/Overlay.md">Community Overlays</a>',
       'Spatial Scale': 'County',
       markdownPrefix: 'BE04 / ',
       markdownText: 'Community Overlays',
@@ -516,7 +516,7 @@ export const variables = {
     {
       'Variable Proxy': 'US counties where 30% of the population identified as Black or African American',
       Source: 'US Census, 2010',
-      Metadata: 'BE04 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/data_final/metadata/Overlay.md">Community Overlays</a>',
+      Metadata: 'BE04 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/Overlay.md">Community Overlays</a>',
       'Spatial Scale': 'County',
       markdownPrefix: 'BE04 / ',
       markdownText: 'Community Overlays',
@@ -526,7 +526,7 @@ export const variables = {
     {
       'Variable Proxy': 'Percent area of total land in Native American Reservations',
       Source: 'US Census, TIGER/Line 2018',
-      Metadata: 'BE04 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/data_final/metadata/Overlay.md">Community Overlays</a>',
+      Metadata: 'BE04 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/Overlay.md">Community Overlays</a>',
       'Spatial Scale': 'County',
       markdownPrefix: 'BE04 / ',
       markdownText: 'Community Overlays',
@@ -536,7 +536,7 @@ export const variables = {
     {
       'Variable Proxy': 'Three index measures of segregation: dissimilarity, interaction, isolation',
       Source: 'ACS, 2018 5-year',
-      Metadata: 'BE05 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/data_final/metadata/Residential_Seg_Indices.md">Residential Segregation</a>',
+      Metadata: 'BE05 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/Residential_Seg_Indices.md">Residential Segregation</a>',
       'Spatial Scale': 'State, County, Zip',
       markdownPrefix: 'BE05 / ',
       markdownText: 'Residential Segregation',
@@ -546,7 +546,7 @@ export const variables = {
     {
       'Variable Proxy': 'Normalized Difference Vegetation Index (NDVI) average value',
       Source: 'Sentinel-2 MSI, 2018',
-      Metadata: 'BE06 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/data_final/metadata/NDVI.md">NDVI</a>',
+      Metadata: 'BE06 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/NDVI.md">NDVI</a>',
       'Spatial Scale': 'State, County, Tract, Zip',
       markdownPrefix: 'BE06 / ',
       markdownText: 'NDVI',
@@ -558,7 +558,7 @@ export const variables = {
     {
       'Variable Proxy': 'Percentage of population employed in Essential Jobs as defined during the COVID-19 pandemic',
       Source: 'ACS, 2018 5-year',
-      Metadata: 'EC02 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/data_final/metadata/Job_Categories_byOccupation_2018.md">Jobs by Occupation</a>',
+      Metadata: 'EC02 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/Job_Categories_byOccupation_2018.md">Jobs by Occupation</a>',
       'Spatial Scale': 'State, County, Tract, Zip',
       markdownPrefix: 'EC02 / ',
       markdownText: 'Jobs by Occupation',
@@ -568,7 +568,7 @@ export const variables = {
     {
       'Variable Proxy': 'Daily cumulative raw case count (01/21/20 - 03/03/2021)',
       Source: 'The New York Times, 2021',
-      Metadata: 'COVID01 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/data_final/metadata/COVID.md">COVID Variables</a>',
+      Metadata: 'COVID01 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/COVID.md">COVID Variables</a>',
       'Spatial Scale': 'State, County',
       markdownPrefix: 'COVID01 / ',
       markdownText: 'COVID Variables',
@@ -578,7 +578,7 @@ export const variables = {
     {
       'Variable Proxy': 'Daily cumulative adjusted case count per 100K population (01/21/20 - 03/03/2021)',
       Source: 'The New York Times, 2021',
-      Metadata: 'COVID02 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/data_final/metadata/COVID.md">COVID Variables</a>',
+      Metadata: 'COVID02 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/COVID.md">COVID Variables</a>',
       'Spatial Scale': 'State, County',
       markdownPrefix: 'COVID02 / ',
       markdownText: 'COVID Variables',
@@ -588,7 +588,7 @@ export const variables = {
     {
       'Variable Proxy': '7-day average case count (01/21/20 - 03/03/2021)',
       Source: 'The New York Times, 2021',
-      Metadata: 'COVID03 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/data_final/metadata/COVID.md">COVID Variables</a>',
+      Metadata: 'COVID03 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/COVID.md">COVID Variables</a>',
       'Spatial Scale': 'State, County',
       markdownPrefix: 'COVID03 / ',
       markdownText: 'COVID Variables',
@@ -598,7 +598,7 @@ export const variables = {
     {
       'Variable Proxy': '7-day average adjusted case count per 100K population (01/21/20 - 03/03/2021)',
       Source: 'The New York Times, 2021',
-      Metadata: 'COVID04 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/data_final/metadata/COVID.md">COVID Variables</a>',
+      Metadata: 'COVID04 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/COVID.md">COVID Variables</a>',
       'Spatial Scale': 'State, County',
       markdownPrefix: 'COVID04 / ',
       markdownText: 'COVID Variables',

--- a/pages/api-docs.js
+++ b/pages/api-docs.js
@@ -89,7 +89,7 @@ export default function About() {
             <p>
               The <code>data</code> endpoint is the main endpoint for accessing datasets. It accepts the following parameters:
               <br/><br/>
-              <code>https://oeps.ssd.uchicago.edu/api/data/<b>dataset</b>/<b>spatial scale</b></code>
+              <code>https://oeps.healthyregions.org/api/data/<b>dataset</b>/<b>spatial scale</b></code>
               <br/><br/>
               Here, dataset should be one of the available tabular datasets, such as <code>Access01</code> or <code>BE02</code> for access metrics, and 
               Physical environment stats, respectively. Spatial scale represents the geographic unit you want to request, and currently we have available county, state, zip, and tract
@@ -115,21 +115,21 @@ export default function About() {
                 <li>
                   Zip code level access metrics for mental health services in Illinois:
                   <br/>
-                  <code>https://oeps.ssd.uchicago.edu/api/data/Access04/zip?key=abc123&amp;state=IL</code>
+                  <code>https://oeps.healthyregions.org/api/data/Access04/zip?key=abc123&amp;state=IL</code>
                   <br/>
                   <br/>
                 </li>
                 <li>
                   State level race and ethnicity data for Virginia, North Carolina, and South Carolina:
                   <br/>
-                  <code>https://oeps.ssd.uchicago.edu/api/data/DS01/state?key=abc123&amp;id=51,37,45</code>
+                  <code>https://oeps.healthyregions.org/api/data/DS01/state?key=abc123&amp;id=51,37,45</code>
                   <br/>
                   <br/>
                 </li>
                 <li>
                   A CSV of workers employed in different job industries by county:
                   <br/>
-                  <code>https://oeps.ssd.uchicago.edu/api/data/EC02/county?key=abc123&amp;format=csv</code>
+                  <code>https://oeps.healthyregions.org/api/data/EC02/county?key=abc123&amp;format=csv</code>
                   <br/>
                   <br/>
                 </li>
@@ -139,7 +139,7 @@ export default function About() {
             <p>
               The <code>docs</code> endpoint returns information on the datasets as markdown with the following parameters:
               <br/><br/>
-              <code>https://oeps.ssd.uchicago.edu/api/data/<b>dataset</b></code>
+              <code>https://oeps.healthyregions.org/api/data/<b>dataset</b></code>
               <br/><br/>
               Here, dataset should be one of the available tabular datasets, such as <code>Access01</code> or <code>BE02</code> for access metrics, and 
               Physical environment stats, respectively. 
@@ -150,14 +150,14 @@ export default function About() {
                 <li>
                   Docs for dataset Access01:
                   <br/>
-                  <code>https://oeps.ssd.uchicago.edu/api/docs/Access01?key=abc123</code>
+                  <code>https://oeps.healthyregions.org/api/docs/Access01?key=abc123</code>
                   <br/>
                   <br/>
                 </li>
                 <li>
                   Docs for dataset DS01:
                   <br/>
-                  <code>https://oeps.ssd.uchicago.edu/api/docs/DS01?key=abc123</code>
+                  <code>https://oeps.healthyregions.org/api/docs/DS01?key=abc123</code>
                   <br/>
                   <br/>
                 </li>
@@ -168,14 +168,14 @@ export default function About() {
               The <code>datasets</code> endpoint returns currently available dataset names. There are no parameters for this endpoint, but you 
               must provide an API key.
               <br/><br/>
-              <code>https://oeps.ssd.uchicago.edu/api/datasets</code>
+              <code>https://oeps.healthyregions.org/api/datasets</code>
               <br/><br/>
               Here is an example queries:
               <ul>
                 <li>
                   Available datasets:
                   <br/>
-                  <code>https://oeps.ssd.uchicago.edu/api/datasets?key=abc123</code>
+                  <code>https://oeps.healthyregions.org/api/datasets?key=abc123</code>
                 </li>
               </ul>
             </p>

--- a/pages/api/data/[...param].js
+++ b/pages/api/data/[...param].js
@@ -53,7 +53,7 @@ export default async function handler(req, res) {
         return;
     }
     if (!keys.includes(key)) {
-        res.status(401).send('Unauthorized API Key. Please contact the UChicago HEROP lab if you are receiving this message in error. If you need an API key, please register at {url coming soon...}')
+        res.status(401).send('Unauthorized API Key. Please contact the Healthy Regions & Policies Lab if you are receiving this message in error. If you need an API key, please register at {url coming soon...}')
         return;
     }
         
@@ -63,7 +63,7 @@ export default async function handler(req, res) {
 
     const baseUrl = req.rawHeaders[req.rawHeaders.indexOf('Host')+1].includes('localhost')
         ? `http://${req.rawHeaders[req.rawHeaders.indexOf('Host')+1]}`
-        : `https://oeps.ssd.uchicago.edu`
+        : `https://oeps.healthyregions.org`
 
     const agg = dataConversion[param[1]]
 

--- a/pages/api/datasets.js
+++ b/pages/api/datasets.js
@@ -19,7 +19,7 @@ export default async (req, res) => {
     }
 
     try {
-        const response = await fetch("https://api.github.com/repos/GeoDaCenter/opioid-policy-scan/git/trees/master?recursive=1")
+        const response = await fetch("https://api.github.com/repos/GeoDaCenter/opioid-policy-scan/git/trees/v1.0?recursive=1")
             .then(r=>r.json())
         const datasets = response.tree.filter(f => (f.path.includes("data_final/") && f.path.includes(".csv")))
             .map(dataset => dataset.path.split('/').slice(-1)[0].split('_')[0])

--- a/pages/api/docs/[dataset].js
+++ b/pages/api/docs/[dataset].js
@@ -6,7 +6,7 @@ const keys = ''
 const cors = initMiddleware(Cors({methods: ['GET', 'POST', 'OPTIONS'],}))
 function onlyUnique(value, index, self) {return self.indexOf(value) === index;}
   
-const baseUrl = 'https://raw.githubusercontent.com/GeoDaCenter/opioid-policy-scan/master/data_final/metadata/'
+const baseUrl = 'https://raw.githubusercontent.com/GeoDaCenter/opioid-policy-scan/v1.0/data_final/metadata/'
 
 const fetchMd = async (url) => {
     try {

--- a/pages/docs/[md].js
+++ b/pages/docs/[md].js
@@ -8,7 +8,7 @@ import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm'
 import Footer from "../../components/layout/Footer";
 
-const BASE_DOCS_URL = 'https://raw.githubusercontent.com/GeoDaCenter/opioid-policy-scan/master/data_final/metadata/'
+const BASE_DOCS_URL = 'https://raw.githubusercontent.com/GeoDaCenter/opioid-policy-scan/v1.0/data_final/metadata/'
 const fetchMarkdown = async (url) => await fetch(url).then(r => r.text()).then(r => r.replace('[here](/data_final).', '[here](/download).'))
 
 export default function MarkdownDocs() {

--- a/pages/docs/index.js
+++ b/pages/docs/index.js
@@ -56,10 +56,10 @@ const ResourceSection=() => {
               <div className="col-xs-12 col-lg-9">
                 <ul>
                   <li> <a href="https://github.com/GeoDaCenter/opioid-policy-scan/tree/v1.0/data_final/moud">MOUD Provider Locations (SAMHSA, 2019)</a></li>
-                  <li> <a href="https://github.com/GeoDaCenter/opioid-policy-scan/tree/v1.0/data_final/Resources">Opioid Treatment Program (OTP) Locations (SAMHSA, 2020)</a> </li>
-                  <li> <a href="https://github.com/GeoDaCenter/opioid-policy-scan/tree/v1.0/data_final/Resources">FQHC Locations (HRSA, 2020)</a></li>
-                  <li> <a href="https://github.com/GeoDaCenter/opioid-policy-scan/tree/v1.0/data_final/Resources">Hospital Locations (CovidCareMap, 2020)</a></li>
-                  <li> <a href="https://github.com/GeoDaCenter/opioid-policy-scan/tree/v1.0/data_final/Resources">Mental Health Provider Locations (SAMHSA, 2020)</a></li>
+                  <li> <a href="https://github.com/GeoDaCenter/opioid-policy-scan/tree/fc3d94053dd1941a96a5945d73cc6f4845453484/data_final/Health%20Resources">Opioid Treatment Program (OTP) Locations (SAMHSA, 2020)</a> </li>
+                  <li> <a href="https://github.com/GeoDaCenter/opioid-policy-scan/tree/fc3d94053dd1941a96a5945d73cc6f4845453484/data_final/Health%20Resources">FQHC Locations (HRSA, 2020)</a></li>
+                  <li> <a href="https://github.com/GeoDaCenter/opioid-policy-scan/tree/fc3d94053dd1941a96a5945d73cc6f4845453484/data_final/Health%20Resources">Hospital Locations (CovidCareMap, 2020)</a></li>
+                  <li> <a href="https://github.com/GeoDaCenter/opioid-policy-scan/tree/fc3d94053dd1941a96a5945d73cc6f4845453484/data_final/Health%20Resources">Mental Health Provider Locations (SAMHSA, 2020)</a></li>
                 </ul>
               </div>
               </div>

--- a/pages/docs/index.js
+++ b/pages/docs/index.js
@@ -55,11 +55,11 @@ const ResourceSection=() => {
               </div>
               <div className="col-xs-12 col-lg-9">
                 <ul>
-                  <li> <a href="https://github.com/GeoDaCenter/opioid-policy-scan/tree/master/data_final/moud">MOUD Provider Locations (SAMHSA, 2019)</a></li>
-                  <li> <a href="https://github.com/GeoDaCenter/opioid-policy-scan/tree/master/data_final/Resources">Opioid Treatment Program (OTP) Locations (SAMHSA, 2020)</a> </li>
-                  <li> <a href="https://github.com/GeoDaCenter/opioid-policy-scan/tree/master/data_final/Resources">FQHC Locations (HRSA, 2020)</a></li>
-                  <li> <a href="https://github.com/GeoDaCenter/opioid-policy-scan/tree/master/data_final/Resources">Hospital Locations (CovidCareMap, 2020)</a></li>
-                  <li> <a href="https://github.com/GeoDaCenter/opioid-policy-scan/tree/master/data_final/Resources">Mental Health Provider Locations (SAMHSA, 2020)</a></li>
+                  <li> <a href="https://github.com/GeoDaCenter/opioid-policy-scan/tree/v1.0/data_final/moud">MOUD Provider Locations (SAMHSA, 2019)</a></li>
+                  <li> <a href="https://github.com/GeoDaCenter/opioid-policy-scan/tree/v1.0/data_final/Resources">Opioid Treatment Program (OTP) Locations (SAMHSA, 2020)</a> </li>
+                  <li> <a href="https://github.com/GeoDaCenter/opioid-policy-scan/tree/v1.0/data_final/Resources">FQHC Locations (HRSA, 2020)</a></li>
+                  <li> <a href="https://github.com/GeoDaCenter/opioid-policy-scan/tree/v1.0/data_final/Resources">Hospital Locations (CovidCareMap, 2020)</a></li>
+                  <li> <a href="https://github.com/GeoDaCenter/opioid-policy-scan/tree/v1.0/data_final/Resources">Mental Health Provider Locations (SAMHSA, 2020)</a></li>
                 </ul>
               </div>
               </div>

--- a/pages/download.js
+++ b/pages/download.js
@@ -175,8 +175,8 @@ export default function Download() {
         <h1 className={styles.title}>Data Download</h1>
         <Gutter em={1} />
         <p>Download all data, or select particular topics or geographic scales.</p>
-        <a className={styles.fullDownload} href="https://github.com/GeoDaCenter/opioid-policy-scan/zipball/master">Download all data <span>ZIP File</span></a>
-        <a className={styles.fullDownload} href="https://github.com/GeoDaCenter/opioid-policy-scan/tarball/master">Download all data <span>TAR Ball</span></a>
+        <a className={styles.fullDownload} href="https://github.com/GeoDaCenter/opioid-policy-scan/zipball/v1.0">Download all data <span>ZIP File</span></a>
+        <a className={styles.fullDownload} href="https://github.com/GeoDaCenter/opioid-policy-scan/tarball/v1.0">Download all data <span>TAR Ball</span></a>
         <a className={styles.fullDownload} href="https://github.com/GeoDaCenter/opioid-policy-scan">View on <span>GitHub</span></a>
         <Gutter em={5} />
         

--- a/pages/download.js
+++ b/pages/download.js
@@ -57,7 +57,7 @@ const geomsDict = [{
   }
 ]
 
-const BASE_CSV_URL = 'https://raw.githubusercontent.com/GeoDaCenter/opioid-policy-scan/master/data_final/'
+const BASE_CSV_URL = 'https://raw.githubusercontent.com/GeoDaCenter/opioid-policy-scan/v1.0/data_final/'
 
 export default function Download() {
   const [downloadMessage, setDownloadMessage] = useState('')


### PR DESCRIPTION
Some cleanup ahead of the 2.0 release, pinning the existing links to proper hashes/release tags in [GeoDaCenter/opioid-policy-scan](https://github.com/GeoDaCenter/opioid-policy-scan).